### PR TITLE
filenameWithoutExtension malloc off by one

### DIFF
--- a/helpers.c
+++ b/helpers.c
@@ -40,7 +40,7 @@ char *filenameWithoutExtension(char *fileName) {
 	for (i = 0; fileName[i] != '\0' && fileName[i] != '.'; i++)
 		;
 	len = i;
-	ret = malloc(sizeof(char) * len);
+	ret = malloc((sizeof(char) * len) + 1);
 	for (i = 0; i < len; i++) {
 		ret[i] = fileName[i];
 	}


### PR DESCRIPTION
valgrind output prior to fixing off by one error:
```
==644434== Memcheck, a memory error detector
==644434== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==644434== Using Valgrind-3.12.0.SVN and LibVEX; rerun with -h for copyright info
==644434== Command: ./yabfc input/a
==644434==
==644434== Invalid write of size 1
==644434==    at 0x4024E1: filenameWithoutExtension (helpers.c:47)
==644434==    by 0x4013FC: main (yabfc.c:80)
==644434==  Address 0x54dc5f7 is 0 bytes after a block of size 7 alloc'd
==644434==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==644434==    by 0x402484: filenameWithoutExtension (helpers.c:43)
==644434==    by 0x4013FC: main (yabfc.c:80)
```