### PR TITLE
get_matching_bracket bail early if instructions struct too small

### DIFF
--- a/helpers.c
+++ b/helpers.c
@@ -71,6 +71,9 @@ void addSectionData(SECTION *section, uint8_t startByte[], uint32_t size) {
  * @return              The relative position of the bracket, -1 if not found
  */
 int get_matching_bracket(INSTRUCTIONS *instructions, int position, bool throwError) {
+	if (instructions->size <= position) 
+		return -1;
+	
 	if (instructions->instruction[position].type != '[') {
 		if (throwError)
 			fprintf(stderr, "No bracket to match at position %i!\n", position);


### PR DESCRIPTION
Avoids this valgrind output:
```
==16650== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==16650==  Bad permissions for mapped region at address 0x403B000
==16650==    at 0x4037CA: get_matching_bracket (helpers.c:75)
==16650==    by 0x405C17: optimize_multiplication (optimize.c:94)
==16650==    by 0x401BCB: main (yabfc.c:137)
```