### PR TITLE
main() off by one error

### DIFF
--- a/yabfc.c
+++ b/yabfc.c
@@ -116,7 +116,7 @@ int main(int argc, char *argv[]) {
 				    .bracketMatch = -1};
 
 				instructions.instruction                      = (INSTRUCTION *)realloc(instructions.instruction, (instructions.size + 1) * sizeof(INSTRUCTION));
-				instructions.instruction[instructions.size++] = tempInstruction;
+				instructions.instruction[instructions.size]   = tempInstruction;
 			}
 		}
 		debugPrintf(2, "\n");


### PR DESCRIPTION
I'm unsure why valgrind shows the error on line 118, when the error is online 119.  However, fixing the array index looks to resolve the issue.

```
==401029== Invalid read of size 1
==401029==    at 0x401B56: main (yabfc.c:141)
==401029==  Address 0x56dfe50 is 0 bytes after a block of size 16 alloc'd
==401029==    at 0x4C2DDCF: realloc (vg_replace_malloc.c:785)
==401029==    by 0x4018E1: main (yabfc.c:118)
```